### PR TITLE
Add logging on an interval and a final report JSON

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	pb "../protos"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"github.com/buoyantio/strest-grpc/client/distribution"
 	"github.com/buoyantio/strest-grpc/client/percentiles"
+	"github.com/codahale/hdrhistogram"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"log"
+	"math"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -18,10 +21,11 @@ import (
 	"time"
 )
 
-const (
-	address     = "localhost:11111"
-	defaultName = "world"
-)
+// MeasuredResponse tracks the latency of a response and any accompaning error.
+type MeasuredResponse struct {
+	latency time.Duration
+	err     error
+}
 
 func exUsage(msg string) {
 	fmt.Fprintf(os.Stderr, "%s\n", msg)
@@ -30,11 +34,55 @@ func exUsage(msg string) {
 	os.Exit(64)
 }
 
+// Report provides top-level good/bad/failed numbers and a latency breakdown.
+type Report struct {
+	Good    int64    `json:"good"`
+	Bad     int64    `json:"bad"`
+	Failed  int64    `json:"failed"`
+	Latency *Latency `json:"latency"`
+}
+
+// Latency Percentiles
+type Latency struct {
+	Quantile50  int64 `json:"50"`
+	Quantile95  int64 `json:"95"`
+	Quantile99  int64 `json:"99"`
+	Quantile999 int64 `json:"999"`
+}
+
+func logFinalReport(good int64, bad int64, failed int64, histogram *hdrhistogram.Histogram) {
+	latency := Latency{
+		Quantile50:  histogram.ValueAtQuantile(50) / 1000000,
+		Quantile95:  histogram.ValueAtQuantile(95) / 1000000,
+		Quantile99:  histogram.ValueAtQuantile(99) / 1000000,
+		Quantile999: histogram.ValueAtQuantile(999) / 1000000,
+	}
+
+	report := Report{
+		Good:    good,
+		Bad:     bad,
+		Failed:  failed,
+		Latency: &latency,
+	}
+
+	if data, err := json.MarshalIndent(report, "", "  "); err != nil {
+		log.Fatal("Unable to generate report: ", err)
+	} else {
+		fmt.Println(string(data))
+	}
+}
+
 func main() {
-	concurrency := flag.Int("concurrency", 1, "client concurrency level")
-	requests := flag.Int("requests", 100, "number of requests per connection")
-	latencyPercentileFlag := flag.String("latencyPercentiles", "0=10,100=1000", "response latency percentile distribution.")
-	lengthPercentileFlag := flag.String("lengthPercentiles", "0=100,100=10000", "response body length percentile distribution.")
+	var (
+		address               = flag.String("address", "localhost:11111", "hostname:port of strest-grpc service or intermediary")
+		concurrency           = flag.Int("concurrency", 1, "client concurrency level")
+		requests              = flag.Int("requests", 10000, "number of requests per connection")
+		interval              = flag.Duration("interval", 10*time.Second, "reporting interval")
+		latencyPercentileFlag = flag.String("latencyPercentiles", "50=10,100=100", "response latency percentile distribution.")
+		lengthPercentileFlag  = flag.String("lengthPercentiles", "50=100,100=1000", "response body length percentile distribution.")
+		disableFinalReport    = flag.Bool("disableFinalReport", false, "do not print a final JSON output report")
+		onlyFinalReport       = flag.Bool("onlyFinalReport", false, "only print the final report, nothing intermediate")
+	)
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n", path.Base(os.Args[0]))
@@ -42,6 +90,10 @@ func main() {
 	}
 
 	flag.Parse()
+
+	if *onlyFinalReport && *disableFinalReport {
+		log.Fatalf("cannot use both -onlyFinalReport and -disableFinalReport.")
+	}
 
 	if *concurrency < 1 {
 		exUsage("concurrency must be at least 1")
@@ -67,17 +119,29 @@ func main() {
 		log.Fatalf("unable to create length distribution: %v", err)
 	}
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	cleanup := make(chan os.Signal)
 	signal.Notify(cleanup, syscall.SIGINT)
+
+	var count, totalCount, good, totalGood, failed, totalFailed, bad, totalBad, max, min int64
+	min = math.MaxInt64
+
+	hist := hdrhistogram.New(0, int64(time.Second), 5)
+	globalHist := hdrhistogram.New(0, int64(time.Second), 5)
+	received := make(chan *MeasuredResponse, 10000)
+
+	var timeout = make(<-chan time.Time)
+	if !*onlyFinalReport {
+		timeout = time.After(*interval)
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(*concurrency)
 
 	for i := int(0); i < *concurrency; i++ {
 		go func() {
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
 			// Set up a connection to the server.
-			conn, err := grpc.Dial(address, grpc.WithInsecure())
+			conn, err := grpc.Dial(*address, grpc.WithInsecure())
 			if err != nil {
 				log.Fatalf("did not connect: %v", err)
 			}
@@ -87,15 +151,18 @@ func main() {
 			for j := int(0); j < *requests; j++ {
 				lengthValue := lengthDistribution.Get(r.Int() % 1000)
 				latencyValue := latencyDistribution.Get(r.Int() % 1000)
-				r, err := c.Get(context.Background(),
+				start := time.Now()
+				_, err := c.Get(context.Background(),
 					&pb.ResponseSpec{
 						Count:   1,
 						Length:  int32(lengthValue),
 						Latency: latencyValue})
+
+				received <- &MeasuredResponse{time.Since(start), err}
+
 				if err != nil {
 					log.Fatalf("could not send a request: %v", err)
 				}
-				log.Printf("Response: %s", r.Body)
 			}
 			wg.Done()
 		}()
@@ -105,12 +172,57 @@ func main() {
 		for {
 			select {
 			case <-cleanup:
-				go func() {
-					os.Exit(1)
-				}()
+				if !*disableFinalReport {
+					logFinalReport(totalGood, totalBad, totalFailed, globalHist)
+				}
+				os.Exit(1)
+			case response := <-received:
+				count++
+				totalCount++
+				if response.err != nil {
+					failed++
+					totalFailed++
+				} else {
+					good++
+					totalGood++
+					latency := response.latency.Nanoseconds()
+					if latency < min {
+						min = latency
+					}
+
+					if latency > max {
+						max = latency
+					}
+
+					hist.RecordValue(latency)
+					globalHist.RecordValue(latency)
+				}
+			case t := <-timeout:
+				if min == math.MaxInt64 {
+					min = 0
+				}
+				// Periodically print stats about the request load.
+				fmt.Printf("%s %6d/%1d/%1d requests %s %3d [%3d %3d %3d %4d ] %4d\n",
+					t.Format(time.RFC3339),
+					good,
+					bad,
+					failed,
+					interval,
+					min/1000000,
+					hist.ValueAtQuantile(50)/1000000,
+					hist.ValueAtQuantile(95)/1000000,
+					hist.ValueAtQuantile(99)/1000000,
+					hist.ValueAtQuantile(999)/1000000,
+					max/1000000)
+				count, good, bad, failed, max, min = 0, 0, 0, 0, 0, math.MaxInt64
+				hist.Reset()
+				timeout = time.After(*interval)
 			}
 		}
 	}()
 
 	wg.Wait()
+	if !*disableFinalReport {
+		logFinalReport(totalGood, totalBad, totalFailed, globalHist)
+	}
 }

--- a/client/percentiles/percentiles.go
+++ b/client/percentiles/percentiles.go
@@ -5,31 +5,27 @@ import (
 	"strings"
 )
 
-/**
- * Given a two-digit percentile value, converts it to a three-digit
- * value
- */
+// ConvertToBetterPercentile takes a two-digit percentile value
+// and converts it to a three-digit value
 func ConvertToBetterPercentile(p int) int {
 	if p > 100 {
 		return p
-	} else {
-		return p * 10
 	}
+
+	return p * 10
 }
 
-/**
- * Given an input of key-value pairs corresponding to percentiles and
- * values, return a map of them. Converts percentiles from two digits
- * to three digits to account for percentiles that aren't whole
- * numbers e.g. 99.9
- *
- * Ex: 50=100,90=200,95=1000,999=20000, we
- * return the following map:
- * p[500] = 100
- * p[900] = 200
- * p[950] = 1000
- * p[999] = 20000
- */
+// ParsePercentiles takes a string of key-value pairs corresponding to
+// percentiles and  values, return a map of them. Converts percentiles
+// from two digits to three digits to account for percentiles that
+// aren't whole numbers e.g. 99.9
+//
+// Ex: 50=100,90=200,95=1000,999=20000, we
+// return the following map:
+// p[500] = 100
+// p[900] = 200
+// p[950] = 1000
+// p[999] = 20000
 func ParsePercentiles(input string) (map[int]int64, error) {
 	var percentiles map[int]int64
 	var ss []string

--- a/server/random_string/random_string.go
+++ b/server/random_string/random_string.go
@@ -4,12 +4,6 @@ import (
 	"math/rand"
 )
 
-/**
- * Fast Random String generation borrowed from
- *  http://stackoverflow.com/a/31832326/793696
- *  https://play.golang.org/p/WIgH7GRnN1
- */
-
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const (
 	letterIdxBits = 6                    // 6 bits to represent a letter index
@@ -17,6 +11,9 @@ const (
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
 
+// Fast Random String generation borrowed from
+//  http://stackoverflow.com/a/31832326/793696
+//  https://play.golang.org/p/WIgH7GRnN1
 func RandStringBytesMaskImprSrc(src rand.Source, n int) string {
 	b := make([]byte, n)
 	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!


### PR DESCRIPTION
- Adds slow_cooker style logging on a configurable interval.
- Makes address configurable.
- Changes the default distributions to start at 50 percentile.
- You can disable either the interval or the final report.
- Fixes #2 
