### PR TITLE
Implement streaming requests/responses with grpc.

### DIFF
--- a/client/distribution/distribution_test.go
+++ b/client/distribution/distribution_test.go
@@ -16,9 +16,9 @@ var _ = Suite(&DistributionTestSuite{})
 func (*DistributionTestSuite) TestMapKeysAreSorted(c *C) {
 	// Empty distribution has no keys
 	empty := distribution.Empty()
-	c.Assert(empty.SortedKeys(), DeepEquals, []int{})
+	c.Assert(empty.SortedKeys(), DeepEquals, []int32{})
 
-	m := map[int]int64{
+	m := map[int32]int64{
 		200: 200,
 		300: 300,
 		400: 400,
@@ -27,12 +27,12 @@ func (*DistributionTestSuite) TestMapKeysAreSorted(c *C) {
 	dist, err := distribution.FromMap(m)
 	c.Assert(err, IsNil)
 	// Tests that the elements are the same regardless of sorting
-	c.Assert(dist.SortedKeys(), DeepEquals, []int{0, 200, 300, 400, 1000})
+	c.Assert(dist.SortedKeys(), DeepEquals, []int32{0, 200, 300, 400, 1000})
 	c.Assert(dist.CheckValidity(), IsNil)
 }
 
 func (*DistributionTestSuite) TestCheckValueFits(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		0:    100,
 		1000: 1000,
 	}
@@ -58,7 +58,7 @@ func (*DistributionTestSuite) TestCheckValueFits(c *C) {
 }
 
 func (*DistributionTestSuite) TestCheckValueFits2(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		0:    100,
 		1000: 1000,
 	}
@@ -76,7 +76,7 @@ func (*DistributionTestSuite) TestCheckValueFits2(c *C) {
 }
 
 func (*DistributionTestSuite) TestFindHighLowKeysLargeValues(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		0:    0,
 		1000: 1100,
 	}
@@ -85,7 +85,7 @@ func (*DistributionTestSuite) TestFindHighLowKeysLargeValues(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(dist), Equals, 2)
 
-	c.Assert(dist.SortedKeys(), DeepEquals, []int{0, 1000})
+	c.Assert(dist.SortedKeys(), DeepEquals, []int32{0, 1000})
 	high, low := dist.FindHighLowKeys(500)
 
 	if low > high {
@@ -101,7 +101,7 @@ func (*DistributionTestSuite) TestFindHighLowKeysLargeValues(c *C) {
 }
 
 func (*DistributionTestSuite) TestFindHighLowKeysSmallValues(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		500: 100,
 		900: 200,
 	}
@@ -129,7 +129,7 @@ func (*DistributionTestSuite) TestEmpty(c *C) {
 }
 
 func (*DistributionTestSuite) TestCheckKeyValueFits(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		1000: 30,
 	}
 
@@ -143,7 +143,7 @@ func (*DistributionTestSuite) TestCheckKeyValueFits(c *C) {
 }
 
 func (*DistributionTestSuite) TestMapApi(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		0:    0,
 		1000: 500,
 	}
@@ -165,7 +165,7 @@ func (*DistributionTestSuite) TestMapApi(c *C) {
 }
 
 func (*DistributionTestSuite) TestMapApiErrors(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		0:    0,
 		1000: 10,
 	}
@@ -177,7 +177,7 @@ func (*DistributionTestSuite) TestMapApiErrors(c *C) {
 }
 
 func (*DistributionTestSuite) TestExtraploateFromMap(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		0:    100,
 		200:  2000,
 		1000: 10000,
@@ -193,7 +193,7 @@ func (*DistributionTestSuite) TestExtraploateFromMap(c *C) {
 }
 
 func (*DistributionTestSuite) TestFromMapGood(c *C) {
-	latencyMap := map[int]int64{
+	latencyMap := map[int32]int64{
 		10:  1,
 		500: 1000,
 		900: 2000,
@@ -216,7 +216,7 @@ func (*DistributionTestSuite) TestFromMapGood(c *C) {
 }
 
 func (*DistributionTestSuite) TestFromMapBad(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		0:   0,
 		500: 200,
 		// 100 doesn't fit the distribution.
@@ -229,7 +229,7 @@ func (*DistributionTestSuite) TestFromMapBad(c *C) {
 }
 
 func (*DistributionTestSuite) TestAddMinMax(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		100: 100,
 	}
 
@@ -242,7 +242,7 @@ func (*DistributionTestSuite) TestAddMinMax(c *C) {
 }
 
 func (*DistributionTestSuite) TestSmallValues(c *C) {
-	m := map[int]int64{
+	m := map[int32]int64{
 		0:    0,
 		500:  50,
 		1000: 100,

--- a/client/main.go
+++ b/client/main.go
@@ -10,12 +10,15 @@ import (
 	"github.com/codahale/hdrhistogram"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"io"
 	"log"
 	"math"
 	"math/rand"
 	"os"
 	"os/signal"
 	"path"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -34,11 +37,10 @@ func exUsage(msg string) {
 	os.Exit(64)
 }
 
-// Report provides top-level good/bad/failed numbers and a latency breakdown.
+// Report provides top-level good/bad numbers and a latency breakdown.
 type Report struct {
 	Good    int64    `json:"good"`
 	Bad     int64    `json:"bad"`
-	Failed  int64    `json:"failed"`
 	Latency *Latency `json:"latency"`
 }
 
@@ -50,7 +52,7 @@ type Latency struct {
 	Quantile999 int64 `json:"999"`
 }
 
-func logFinalReport(good int64, bad int64, failed int64, histogram *hdrhistogram.Histogram) {
+func logFinalReport(good int64, bad int64, histogram *hdrhistogram.Histogram) {
 	latency := Latency{
 		Quantile50:  histogram.ValueAtQuantile(50) / 1000000,
 		Quantile95:  histogram.ValueAtQuantile(95) / 1000000,
@@ -61,7 +63,6 @@ func logFinalReport(good int64, bad int64, failed int64, histogram *hdrhistogram
 	report := Report{
 		Good:    good,
 		Bad:     bad,
-		Failed:  failed,
 		Latency: &latency,
 	}
 
@@ -72,16 +73,113 @@ func logFinalReport(good int64, bad int64, failed int64, histogram *hdrhistogram
 	}
 }
 
+func sendNonStreamingRequests(client pb.ResponderClient,
+	requests int64, lengthDistribution distribution.Distribution,
+	latencyDistribution distribution.Distribution, r *rand.Rand,
+	received chan *MeasuredResponse) error {
+	for j := int64(0); j < requests; j++ {
+		start := time.Now()
+		_, err := client.Get(context.Background(),
+			&pb.ResponseSpec{
+				Length:  int32(lengthDistribution.Get(r.Int31() % 1000)),
+				Latency: latencyDistribution.Get(r.Int31() % 1000)})
+
+		received <- &MeasuredResponse{time.Since(start), err}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// parseStreamingRatio takes a string formatted as integer:integer,
+// treats it as m:n and returns (m, n)
+func parseStreamingRatio(streamingRatio string) (int64, int64) {
+	possibleNumbers := strings.Split(streamingRatio, ":")
+
+	if len(possibleNumbers) < 2 {
+		log.Fatalf("streamingRatio '%s' didn't contain two numbers\n", streamingRatio)
+	}
+
+	var m, n int64
+	var err error
+
+	if m, err = strconv.ParseInt(possibleNumbers[0], 10, 64); err != nil {
+		log.Fatalf("unable to parse left-hand side of streamingRatio '%s' due to error: '%v'\n", streamingRatio, err)
+	}
+
+	if n, err = strconv.ParseInt(possibleNumbers[1], 10, 64); err != nil {
+		log.Fatalf("unable to parse right-hand side of streamingRatio '%s' due to error '%v'\n", streamingRatio, err)
+	}
+
+	return m, n
+}
+
+func sendStreamingRequests(client pb.ResponderClient,
+	requests int64, lengthDistribution distribution.Distribution,
+	latencyDistribution distribution.Distribution, streamingRatio string,
+	r *rand.Rand, received chan *MeasuredResponse) error {
+	stream, err := client.StreamingGet(context.Background())
+	if err != nil {
+		log.Fatalf("%v.StreamingGet(_) = _, %v", client, err)
+	}
+
+	waitc := make(chan struct{})
+	go func() {
+		for {
+			start := time.Now()
+			_, err := stream.Recv()
+			elapsed := time.Since(start)
+
+			if err == io.EOF {
+				// read done.
+				close(waitc)
+				return
+			}
+
+			received <- &MeasuredResponse{elapsed, err}
+		}
+	}()
+
+	requestRatioM, requestRatioN := parseStreamingRatio(streamingRatio)
+	var numRequests = int64(0)
+	for j := int64(0); j < requests; j++ {
+		if (j % requestRatioM) == 0 {
+			numRequests = requestRatioN
+		}
+
+		err := stream.Send(&pb.StreamingResponseSpec{
+			Count:              int32(numRequests),
+			LatencyPercentiles: latencyDistribution.ToMap(),
+			LengthPercentiles:  lengthDistribution.ToMap(),
+		})
+
+		if err != nil {
+			log.Fatalf("Failed to Send ResponseSpec: %v", err)
+		}
+
+		numRequests = 0
+	}
+
+	stream.CloseSend()
+	<-waitc
+	return nil
+}
+
 func main() {
 	var (
 		address               = flag.String("address", "localhost:11111", "hostname:port of strest-grpc service or intermediary")
 		concurrency           = flag.Int("concurrency", 1, "client concurrency level")
-		requests              = flag.Int("requests", 10000, "number of requests per connection")
+		requests              = flag.Int64("requests", 10000, "number of requests per connection")
 		interval              = flag.Duration("interval", 10*time.Second, "reporting interval")
 		latencyPercentileFlag = flag.String("latencyPercentiles", "50=10,100=100", "response latency percentile distribution.")
 		lengthPercentileFlag  = flag.String("lengthPercentiles", "50=100,100=1000", "response body length percentile distribution.")
 		disableFinalReport    = flag.Bool("disableFinalReport", false, "do not print a final JSON output report")
 		onlyFinalReport       = flag.Bool("onlyFinalReport", false, "only print the final report, nothing intermediate")
+		streaming             = flag.Bool("streaming", false, "use the streaming features of strest server")
+		streamingRatio        = flag.String("streamingRatio", "1:1", "the ratio of streaming requests/responses")
 	)
 
 	flag.Usage = func() {
@@ -122,7 +220,7 @@ func main() {
 	cleanup := make(chan os.Signal)
 	signal.Notify(cleanup, syscall.SIGINT)
 
-	var count, totalCount, good, totalGood, failed, totalFailed, bad, totalBad, max, min int64
+	var count, totalCount, good, totalGood, bad, totalBad, max, min int64
 	min = math.MaxInt64
 
 	hist := hdrhistogram.New(0, int64(time.Second), 5)
@@ -146,24 +244,22 @@ func main() {
 				log.Fatalf("did not connect: %v", err)
 			}
 			defer conn.Close()
-			c := pb.NewResponderClient(conn)
+			client := pb.NewResponderClient(conn)
 
-			for j := int(0); j < *requests; j++ {
-				lengthValue := lengthDistribution.Get(r.Int() % 1000)
-				latencyValue := latencyDistribution.Get(r.Int() % 1000)
-				start := time.Now()
-				_, err := c.Get(context.Background(),
-					&pb.ResponseSpec{
-						Count:   1,
-						Length:  int32(lengthValue),
-						Latency: latencyValue})
-
-				received <- &MeasuredResponse{time.Since(start), err}
-
+			if !*streaming {
+				err := sendNonStreamingRequests(client,
+					*requests, lengthDistribution, latencyDistribution, r, received)
+				if err != nil {
+					log.Fatalf("could not send a request: %v", err)
+				}
+			} else {
+				err := sendStreamingRequests(client,
+					*requests, lengthDistribution, latencyDistribution, *streamingRatio, r, received)
 				if err != nil {
 					log.Fatalf("could not send a request: %v", err)
 				}
 			}
+
 			wg.Done()
 		}()
 	}
@@ -173,15 +269,15 @@ func main() {
 			select {
 			case <-cleanup:
 				if !*disableFinalReport {
-					logFinalReport(totalGood, totalBad, totalFailed, globalHist)
+					logFinalReport(totalGood, totalBad, globalHist)
 				}
 				os.Exit(1)
 			case response := <-received:
 				count++
 				totalCount++
 				if response.err != nil {
-					failed++
-					totalFailed++
+					bad++
+					totalBad++
 				} else {
 					good++
 					totalGood++
@@ -202,11 +298,10 @@ func main() {
 					min = 0
 				}
 				// Periodically print stats about the request load.
-				fmt.Printf("%s %6d/%1d/%1d requests %s %3d [%3d %3d %3d %4d ] %4d\n",
+				fmt.Printf("%s %6d/%1d responses %s %3d [%3d %3d %3d %4d ] %4d\n",
 					t.Format(time.RFC3339),
 					good,
 					bad,
-					failed,
 					interval,
 					min/1000000,
 					hist.ValueAtQuantile(50)/1000000,
@@ -214,7 +309,7 @@ func main() {
 					hist.ValueAtQuantile(99)/1000000,
 					hist.ValueAtQuantile(999)/1000000,
 					max/1000000)
-				count, good, bad, failed, max, min = 0, 0, 0, 0, 0, math.MaxInt64
+				count, good, bad, max, min = 0, 0, 0, 0, math.MaxInt64
 				hist.Reset()
 				timeout = time.After(*interval)
 			}
@@ -223,6 +318,6 @@ func main() {
 
 	wg.Wait()
 	if !*disableFinalReport {
-		logFinalReport(totalGood, totalBad, totalFailed, globalHist)
+		logFinalReport(totalGood, totalBad, globalHist)
 	}
 }

--- a/client/percentiles/percentiles.go
+++ b/client/percentiles/percentiles.go
@@ -7,7 +7,7 @@ import (
 
 // ConvertToBetterPercentile takes a two-digit percentile value
 // and converts it to a three-digit value
-func ConvertToBetterPercentile(p int) int {
+func ConvertToBetterPercentile(p int32) int32 {
 	if p > 100 {
 		return p
 	}
@@ -26,18 +26,18 @@ func ConvertToBetterPercentile(p int) int {
 // p[900] = 200
 // p[950] = 1000
 // p[999] = 20000
-func ParsePercentiles(input string) (map[int]int64, error) {
-	var percentiles map[int]int64
+func ParsePercentiles(input string) (map[int32]int64, error) {
+	var percentiles map[int32]int64
 	var ss []string
 
 	ss = strings.Split(input, ",")
-	percentiles = make(map[int]int64)
+	percentiles = make(map[int32]int64)
 	for _, pair := range ss {
 		z := strings.Split(pair, "=")
 		percentile, errPercentile := strconv.ParseInt(z[0], 10, 32)
 		value, errValue := strconv.ParseInt(z[1], 10, 64)
 		if errPercentile == nil && errValue == nil {
-			percentiles[ConvertToBetterPercentile(int(percentile))] = value
+			percentiles[ConvertToBetterPercentile(int32(percentile))] = value
 		} else {
 			if errPercentile != nil {
 				return nil, errPercentile

--- a/protos/strest.proto
+++ b/protos/strest.proto
@@ -5,15 +5,22 @@ package strest;
 service Responder {
   // Sends a greeting
   rpc Get(ResponseSpec) returns (ResponseReply) {}
+  rpc StreamingGet(stream StreamingResponseSpec) returns (stream ResponseReply) {}
 }
 
 message ResponseSpec {
-  // number of frames to return
-  int32 count = 1;
   // how many bytes we expect in return.
-  int32 length = 2;
+  int32 length = 1;
   // how long (in milliseconds) we want the response to wait.
-  int64 latency = 3;
+  int64 latency = 2;
+}
+
+message StreamingResponseSpec {
+  // how many responses to send.
+  int32 count = 1;
+  // distributions for latency and length
+  map<int32, int64> latencyPercentiles = 4;
+  map<int32, int64> lengthPercentiles = 5;
 }
 
 // The response message containing the greetings

--- a/server/main.go
+++ b/server/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	pb "../protos"
+	"errors"
+	"github.com/buoyantio/strest-grpc/client/distribution"
 	"github.com/buoyantio/strest-grpc/server/random_string"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -15,10 +18,69 @@ const port = ":11111"
 
 type server struct{}
 
+// Get returns a single response after waiting for in.Count
+// milliseconds.
 func (s *server) Get(ctx context.Context, in *pb.ResponseSpec) (*pb.ResponseReply, error) {
 	var src = rand.NewSource(time.Now().UnixNano())
-	time.Sleep(time.Duration(in.Latency) * time.Millisecond)
+	if in.Latency > 0 {
+		time.Sleep(time.Duration(in.Latency) * time.Millisecond)
+	}
 	return &pb.ResponseReply{Body: random_string.RandStringBytesMaskImprSrc(src, int(in.Length))}, nil
+}
+
+// StreamingGet implements a streaming request/response.
+// The ResponseSpec specifies how many and what size/latency responses
+// to send.
+func (s *server) StreamingGet(stream pb.Responder_StreamingGetServer) error {
+	var src = rand.NewSource(time.Now().UnixNano())
+	r := rand.New(src)
+
+	for {
+		spec, err := stream.Recv()
+
+		if err == io.EOF {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if spec.Count < 0 {
+			return errors.New("invalid ResponseSpec, Count cannot be negative")
+		}
+
+		if spec.Count == 0 {
+			return nil
+		}
+
+		latencyDistribution, err := distribution.FromMap(spec.LatencyPercentiles)
+		if err != nil {
+			return err
+		}
+
+		lengthDistribution, err := distribution.FromMap(spec.LengthPercentiles)
+		if err != nil {
+			return err
+		}
+
+		for i := int32(0); i < spec.Count; i++ {
+			timeToSleep := latencyDistribution.Get(r.Int31() % 1000)
+			bodySize := lengthDistribution.Get(r.Int31() % 1000)
+
+			if timeToSleep > 0 {
+				time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
+			}
+
+			response := &pb.ResponseReply{
+				Body: random_string.RandStringBytesMaskImprSrc(src, int(bodySize)),
+			}
+
+			if err := stream.Send(response); err != nil {
+				return err
+			}
+		}
+	}
 }
 
 func main() {


### PR DESCRIPTION
- Streaming is gated behind `-streaming`.
- You can specify a ratio of M:N requests/responses with `-streamingRatio`.
- I could not differentiate between bad and failed so we only track failed now.
- You can't serialize a bare `int` with protobufs so I switched `Distribution` to `int32`
- You can't sort `[]int32` with the stdlib so I made `[]int32` implement `sort.Interface`
- The `int32` change is a lot of noise (sorry. 😦 )
