### PR TITLE
Add README, CHANGES, tweak command line flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+First release 🎈

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# strest-grpc
+
+Strest client and server implementations for gRPC.
+
+## Running Locally
+
+To run the client and server locally, first start the server.
+
+```
+$ go run server/main.go
+starting gRPC server on :11111
+```
+
+Next run the client. By default, the client will send as many request as it can
+on a single connection for 10 seconds, and exit with a performance report.
+
+```
+$ go run client/main.go --address localhost:11111
+2017-05-12T16:17:40-07:00  98.2KB    354/0 10s L:   0 [ 89  97 ]  102 J:   0   0
+{
+  "good": 354,
+  "bad": 0,
+  "bytes": 100556,
+  "latency": {
+    "50": 10,
+    "95": 89,
+    "99": 97,
+    "999": 102
+  },
+  "jitter": {
+    "50": 0,
+    "95": 0,
+    "99": 0,
+    "999": 0
+  }
+}
+```
+
+### Flags
+
+Use the `-help` flag with either the client or server to see a list of flags.
+
+## Building
+
+To build the client and server binaries, run:
+
+```
+./bin/release.sh
+```
+
+That will create `strest-client-linux` and `strest-server-linux` binaries in the
+root of the project.
+
+To build a docker image, run:
+
+```
+$ docker build -t buoyantio/strest-grpc:latest .
+```
+
+Replace `latest` with whatever tag you are trying to build.
+
+## Releasing
+
+To release:
+
+* Update and submit a PR with a changelog for the release in [CHANGES.md](CHANGES.md).
+* Merge the changelog PR.
+* Build the client and server binaries as described in the [Building](#building) section above.
+* Use Github to [create a new release](https://github.com/BuoyantIO/strest-grpc/releases/new).
+* Add the binaries that you built as attachments to the release.
+* The docker image is built automatically once the release is created.

--- a/client/main.go
+++ b/client/main.go
@@ -452,7 +452,7 @@ func main() {
 				latencyHist.Reset()
 				jitterHist.Reset()
 				timeout = time.After(*interval)
-				if totalCount > 0 && totalCount > *totalRequests {
+				if *totalRequests > 0 && totalCount > *totalRequests {
 					cleanup <- struct{}{}
 				}
 			}
@@ -460,9 +460,5 @@ func main() {
 	}()
 
 	wg.Wait()
-
-	if !*disableFinalReport {
-		logFinalReport(totalGood, totalBad, totalBytes, globalLatencyHist, globalJitterHist)
-	}
 	os.Exit(0)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -22,8 +22,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const port = ":11111"
-
 type server struct{}
 
 var (
@@ -138,7 +136,9 @@ func (s *server) StreamingGet(stream pb.Responder_StreamingGetServer) error {
 }
 
 func main() {
-	help := flag.Bool("help", false, "show help message")
+	rand.Seed(time.Now().UnixNano())
+
+	address := flag.String("address", ":11111", "hostname:port to serve on")
 	metricAddr := flag.String("metric-addr", "", "address to serve metrics on")
 
 	flag.Usage = func() {
@@ -148,11 +148,6 @@ func main() {
 
 	flag.Parse()
 
-	if *help {
-		flag.Usage()
-		os.Exit(64)
-	}
-
 	if *metricAddr != "" {
 		registerMetrics()
 		go func() {
@@ -160,8 +155,10 @@ func main() {
 			http.ListenAndServe(*metricAddr, nil)
 		}()
 	}
-	rand.Seed(time.Now().UnixNano())
-	lis, err := net.Listen("tcp", port)
+
+	fmt.Println("starting gRPC server on", *address)
+
+	lis, err := net.Listen("tcp", *address)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
Some miscellaneous tweaks, as follows:

* Add README.md with info about running, building, and releasing
* Add CHANGES.md and prepare for the 0.0.1 release
* Add an `-address` flag to the server, for running on different ports
* Remove redundant help message code in the server
* Fix issue with client double reporting on exit
* Fix issue with client not sending an infinite number of requests