### PR TITLE
Fix prometheus stats reporting, prep for next release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## 0.0.2
+
+* Add a configurable `-clientTimeout` flag
+* Add more info to the readme, including list of all available flags
+* Fix prometheus stats reporting
+* Fix unary request generator seg fault when request can't be sent
+* Fix issue with partial intermediary reports not being printed
+* Rename `-disableFinalReport` flag to `-noFinalReport`
+* Rename `-onlyFinalReport` flag to `-noIntervalReport`
+
 ## 0.0.1
 
 First release 🎈

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ Use the `-help` flag with either the client or server to see a list of flags.
 | Flag                  | Default   | Description |
 |-----------------------|-----------|-------------|
 | `-address`            | `localhost:11111` | hostname:port of strest-grpc service or intermediary. |
-| `-qps`                | `1`       | QPS to send to backends per request thread. |
+| `-clientTimeout`      | `<none>`  | Timeout for unary client request. No timeout is applied if unset. |
 | `-concurrency`        | `1`       | Number of goroutines to run, each at the specified QPS level. Measure total QPS as `qps * concurrency`. |
 | `-interval`           | `10s`     | How often to report stats to stdout. |
-| `-totalRequests`      | `<none>`  | Exit after sending this many requests. |
+| `-latencyPercentiles` | `50=10,100=100` | response latency percentile distribution in milliseconds. |
+| `-lengthPercentiles`  | `50=100,100=1000` | response body length percentile. |
 | `-metric-addr`        | `<none>`  | Address to use when serving the Prometheus `/metrics` endpoint. No metrics are served if unset. Format is `host:port` or `:port`. |
 | `-noFinalReport`      | `<unset>` | If set, don't print the json latency report at the end. |
 | `-noIntervalReport`   | `<unset>` | If set, only print the final report, nothing intermediate. |
-| `-latencyPercentiles` | `50=10,100=100` | response latency percentile distribution in milliseconds. |
-| `-lengthPercentiles`  | `50=100,100=1000` | response body length percentile. |
 | `-streaming`          | `<unset>` | response is a gRPC stream from the strest server. |
 | `-streamingRatio`     | `1:1`     | the ratio of streaming requests/responses if streaming is enabled. |
+| `-totalRequests`      | `<none>`  | Exit after sending this many requests. |
 | `-help`               | `<unset>` | If set, print all available flags and exit. |
 
 ## Building


### PR DESCRIPTION
Fixes a few issues with stats reporting:

* `requests` stat was not being incremented
* `responses` stat was not being incremented (also renamed to `successes` to match slow_cooker)
* `latency_ms` was being measured in nanoseconds

Also updating the README and CHANGES to prep for a 0.0.2 release.