### PR TITLE
latency unit command line option

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -326,7 +326,7 @@ func main() {
 
 	flag.Parse()
 	
-	latencyunit := 100
+	latencyunit := 1000000
 	if *latencyUnit == "milli" {
 		latencyunit = 1000000
 	}else if *latencyUnit == "micro" {


### PR DESCRIPTION
@stevej  
I have added latency unit option, linkerd impact is <1 ms hence cannot be measured at milli second accuracy level