### PR TITLE
Rename the -metric-addr flag to -metricAddr

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use the `-help` flag with either the client or server to see a list of flags.
 | `-latencyPercentiles` | `50=10,100=100` | response latency percentile distribution in milliseconds. |
 | `-lengthPercentiles`  | `50=100,100=1000` | response body length percentile. |
 | `-errorRate`          | `0`       | The chance to return an error. |
-| `-metricAddr`        | `<none>`  | Address to use when serving the Prometheus `/metrics` endpoint. No metrics are served if unset. Format is `host:port` or `:port`. |
+| `-metricAddr`         | `<none>`  | Address to use when serving the Prometheus `/metrics` endpoint. No metrics are served if unset. Format is `host:port` or `:port`. |
 | `-noFinalReport`      | `<unset>` | If set, don't print the json latency report at the end. |
 | `-noIntervalReport`   | `<unset>` | If set, only print the final report, nothing intermediate. |
 | `-streaming`          | `<unset>` | response is a gRPC stream from the strest server. |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use the `-help` flag with either the client or server to see a list of flags.
 | `-latencyPercentiles` | `50=10,100=100` | response latency percentile distribution in milliseconds. |
 | `-lengthPercentiles`  | `50=100,100=1000` | response body length percentile. |
 | `-errorRate`          | `0`       | The chance to return an error. |
-| `-metric-addr`        | `<none>`  | Address to use when serving the Prometheus `/metrics` endpoint. No metrics are served if unset. Format is `host:port` or `:port`. |
+| `-metricAddr`        | `<none>`  | Address to use when serving the Prometheus `/metrics` endpoint. No metrics are served if unset. Format is `host:port` or `:port`. |
 | `-noFinalReport`      | `<unset>` | If set, don't print the json latency report at the end. |
 | `-noIntervalReport`   | `<unset>` | If set, only print the final report, nothing intermediate. |
 | `-streaming`          | `<unset>` | response is a gRPC stream from the strest server. |

--- a/client/main.go
+++ b/client/main.go
@@ -319,7 +319,7 @@ func main() {
 		noIntervalReport      = flag.Bool("noIntervalReport", false, "only print the final report, nothing intermediate")
 		streaming             = flag.Bool("streaming", false, "use the streaming features of strest server")
 		streamingRatio        = flag.String("streamingRatio", "1:1", "the ratio of streaming requests/responses")
-		metricAddr            = flag.String("metric-addr", "", "address to serve metrics on")
+		metricAddr            = flag.String("metricAddr", "", "address to serve metrics on")
 	)
 
 	flag.Usage = func() {

--- a/server/main.go
+++ b/server/main.go
@@ -147,7 +147,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	address := flag.String("address", ":11111", "hostname:port to serve on")
-	metricAddr := flag.String("metric-addr", "", "address to serve metrics on")
+	metricAddr := flag.String("metricAddr", "", "address to serve metrics on")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s <url> [flags]\n", path.Base(os.Args[0]))


### PR DESCRIPTION
It's confusing to mix option naming styles.