### PR TITLE
Add -totalTargetRps

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 
-set -x
+set -ex
 
-GOOS=linux GOARCH=amd64 go build -o strest-server-linux server/main.go
-GOOS=linux GOARCH=amd64 go build -o strest-client-linux client/main.go
-GOOS=linux GOARCH=amd64 go build -o strest-max-rps-linux max-rps/main.go
+export GOARCH=amd64
+
+for GOOS in darwin linux ; do
+    dir="release/$GOOS"
+    mkdir -p "$dir"
+
+    export GOOS
+    go build -o "$dir/strest-grpc-client" client/main.go
+    go build -o "$dir/strest-grpc-server" server/main.go
+    go build -o "$dir/strest-grpc-max-rps" max-rps/main.go
+done

--- a/client/main.go
+++ b/client/main.go
@@ -414,13 +414,8 @@ func main() {
 	capacity := concurrency
 
 	if *totalTargetRps > 0 {
-		// If a target throughput is set, however, we can't know how much work will be queued
-		// at any point.
-		if *totalRequests == 0 {
-			capacity = 10000 // ¯\_(ツ)_/¯
-		} else {
-			capacity = *totalRequests
-		}
+		// Allow several seconds worth of additional capacity in case things back up.
+		capacity = *totalTargetRps * 10
 	}
 
 	// Items are sent to this channel to inform sending goroutines when to do work.

--- a/client/main.go
+++ b/client/main.go
@@ -427,9 +427,7 @@ func main() {
 	// goroutine that a full concurrency of work should be driven.
 	var driveTick <-chan time.Time
 	if *totalTargetRps > 0 {
-		tps := *totalTargetRps / concurrency
-		interval := uint(time.Second) / tps
-		driveTick = time.Tick(time.Duration(int(interval)))
+		driveTick = time.Tick(time.Second)
 	}
 
 	// Drive a single request.
@@ -564,8 +562,8 @@ func main() {
 				return
 
 			case <-driveTick:
-				// This only fires when there is a target rps. Drive at most
-				// totalTargetRps requests.
+				// When a target rps is set, it may fire several times a second so that a
+				// full concurrency of work may be scheduled at each interval.
 
 				n := *totalTargetRps
 


### PR DESCRIPTION
strest-grpc currently lacks any way to set a throughput target for
tests.  Furthermore, the -totalRequests flag behaves incorrectly (where
more requests may be sent).

Now, work is driven and limited by the main goroutine so that work stops
appropriately.

When -totalTargetRps is set, a timer is created to schedule a concurrent
workload at a stready rate.