### PR TITLE
Add support for Unix Domain Sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 strest-server*
 strest-client*
 strest-max-rps*
+release/
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,13 @@
+## Upcoming: 0.1.0
+
+* Add support for Unix Domain sockets.
+
 ## 0.0.3
 
 * Add `strest-max-rps`, a tool for determining the max RPS of a backend.
 * [client] Add `-totalTargetRps` to throttle requests to a fixed rate.
-* [client] Rename `-concurrency` to `-connections`
-* [client] Add `-streams` to configure per-connection concurrency
+* [client] Rename `-concurrency` to `-connections`.
+* [client] Add `-streams` to configure per-connection concurrency.
 * [client] Add `-tlsTrustChainFile` to cause the client to establish and validate TLS connections.
 * [server] Add `-tlsCertFile` and `-tlsPrivKeyFile`, which causes the server to accept TLS connections.
 * [client] Do not add latency by default.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Use the `-help` flag with either the client or server to see a list of flags.
 | Flag                  | Default   | Description |
 |-----------------------|-----------|-------------|
 | `-address`            | `localhost:11111` | hostname:port of strest-grpc service or intermediary. |
+| `-unix`               | false     | Causes the `address` to be interpreted as a Unix Domain Socket. |
 | `-clientTimeout`      | `<none>`  | Timeout for unary client request. No timeout is applied if unset. |
 | `-concurrency`        | `1`       | Number of goroutines to run, each at the specified QPS level. Measure total QPS as `qps * concurrency`. |
 | `-interval`           | `10s`     | How often to report stats to stdout. |

--- a/client/main.go
+++ b/client/main.go
@@ -487,7 +487,11 @@ func main() {
 	af := "tcp"
 	if *useUnixAddr {
 		af = "unix"
+
+		// Override the authority so it doesn't include something illegal like a path.
+		connOpts = append(connOpts, grpc.WithAuthority("strest.local"))
 	}
+
 	dial := func(addr string, timeout time.Duration) (net.Conn, error) {
 		return net.DialTimeout(af, addr, timeout)
 	}

--- a/client/main.go
+++ b/client/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -328,7 +329,8 @@ func sendStreamingRequests(worker workerID,
 
 func main() {
 	var (
-		address               = flag.String("address", "localhost:11111", "hostname:port of strest-grpc service or intermediary")
+		address               = flag.String("address", "localhost:11111", "address of strest-grpc service or intermediary")
+		useUnixAddr           = flag.Bool("unix", false, "use Unix Domain Sockets instead of TCP")
 		clientTimeout         = flag.Duration("clientTimeout", 0, "timeout for unary client requests. Default: no timeout")
 		connections           = flag.Uint("connections", 1, "number of concurrent connections")
 		streams               = flag.Uint("streams", 1, "number of concurrent streams per connection")
@@ -482,6 +484,15 @@ func main() {
 		connOpts = append(connOpts, grpc.WithInsecure())
 	}
 
+	af := "tcp"
+	if *useUnixAddr {
+		af = "unix"
+	}
+	dial := func(addr string, timeout time.Duration) (net.Conn, error) {
+		return net.DialTimeout(af, addr, timeout)
+	}
+	connOpts = append(connOpts, grpc.WithDialer(dial))
+
 	for c := uint(0); c < *connections; c++ {
 		c := c
 		shutdowns := shutdownChannels[c]
@@ -492,7 +503,6 @@ func main() {
 			var connWait sync.WaitGroup
 			connWait.Add(int(*streams))
 
-			// Set up a connection to the server.
 			conn, err := grpc.Dial(*address, connOpts...)
 			if err != nil {
 				log.Fatalf("did not connect: %v", err)

--- a/server/main.go
+++ b/server/main.go
@@ -147,7 +147,8 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	var (
-		address        = flag.String("address", ":11111", "hostname:port to serve on")
+		address        = flag.String("address", ":11111", "address to serve on")
+		useUnixAddr    = flag.Bool("unix", false, "use Unix Domain Sockets instead of TCP")
 		metricAddr     = flag.String("metricAddr", "", "address to serve metrics on")
 		tlsCertFile    = flag.String("tlsCertFile", "", "the path to the trust certificate")
 		tlsPrivKeyFile = flag.String("tlsPrivKeyFile", "", "the path to the server's private key")
@@ -170,9 +171,13 @@ func main() {
 
 	fmt.Println("starting gRPC server on", *address)
 
-	lis, err := net.Listen("tcp", *address)
+	af := "tcp"
+	if *useUnixAddr {
+		af = "unix"
+	}
+	lis, err := net.Listen(af, *address)
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		log.Fatalf("listening on %s:%s: %v", af, *address, err)
 	}
 
 	var opts []grpc.ServerOption


### PR DESCRIPTION
When the -unix flag is passed to a strest client or server, the address field is taken to be a filesystem path like `/tmp/socket` or an abstract name like `@strest`.