### PR TITLE
Fix default client address to match server

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Usage:
   strest-grpc client [flags]
 
 Flags:
-      --address string              address of strest-grpc service or intermediary (default "localhost:1111")
+      --address string              address of strest-grpc service or intermediary (default "localhost:11111")
       --clientTimeout duration      timeout for unary client requests. Default: no timeout
       --connections uint            number of concurrent connections (default 1)
       --errorRate float             the chance to return an error

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -21,7 +21,7 @@ var clientCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(clientCmd)
 	flags := clientCmd.Flags()
-	flags.StringVar(&clientCfg.Address, "address", "localhost:1111", "address of strest-grpc service or intermediary")
+	flags.StringVar(&clientCfg.Address, "address", "localhost:11111", "address of strest-grpc service or intermediary")
 	flags.BoolVarP(&clientCfg.UseUnixAddr, "unix", "u", false, "use Unix Domain Sockets instead of TCP")
 	flags.DurationVar(&clientCfg.ClientTimeout, "clientTimeout", 0, "timeout for unary client requests. Default: no timeout")
 	flags.UintVar(&clientCfg.Connections, "connections", 1, "number of concurrent connections")


### PR DESCRIPTION
strest-grpc server defaults to :11111, but the client's default was
localhost:1111.

Modify the client's default address to localhost:11111.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>