### PR TITLE
docker: Build static binaries into scratch images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+CHANGES.md
+Dockerfile
+README.md
+bin
+circle.yml
+release

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 CHANGES.md
 Dockerfile
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ ADD . /go/src/github.com/buoyantio/strest-grpc
 RUN CGO_ENABLED=0 go build -installsuffix cgo -o /go/bin/strest-grpc /go/src/github.com/buoyantio/strest-grpc/main.go
 
 FROM scratch
-COPY --from=golang /go/bin /go/bin
+COPY --from=build /go/bin /go/bin
 ENTRYPOINT ["/go/bin/strest-grpc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.9.2-alpine
-
+FROM golang:1.10.2 as build
 WORKDIR /go/src/strest-grpc
-
 ADD . /go/src/github.com/buoyantio/strest-grpc
+RUN CGO_ENABLED=0 go build -installsuffix cgo -o /go/bin/strest-grpc /go/src/github.com/buoyantio/strest-grpc/main.go
 
-RUN go build -o /go/bin/strest-grpc /go/src/github.com/buoyantio/strest-grpc/main.go
-
+FROM scratch
+COPY --from=golang /go/bin /go/bin
 ENTRYPOINT ["/go/bin/strest-grpc"]


### PR DESCRIPTION
Previously, we used an older go alpine image. Rather than use an alpine image,
we can just build static binaries from a normal go image and publish them into
a scratch image.

Update to go 1.10.2.

Add a .dockerignore to prevent releases from being copied into the docker server.