### PR TITLE
Introduce reference client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Available Commands:
   client      run the strest-grpc client
   help        Help about any command
   max-rps     compute max RPS
+  ref-client  run a gRPC reference client
+  ref-server  run a gRPC reference server
   server      run the strest-grpc server
 
 Flags:
@@ -138,6 +140,38 @@ Flags:
       --concurrencyLevels string   levels of concurrency to test with (default "1,5,10,20,30")
   -h, --help                       help for max-rps
       --timePerLevel duration      how much time to spend testing each concurrency level (default 1s)
+
+Global Flags:
+  -l, --logLevel string   log level, must be one of: panic, fatal, error, warn, info, debug (default "info")
+```
+
+#### Ref-Client
+
+```
+$ strest-grpc ref-client --help
+run a gRPC reference client
+
+Usage:
+  strest-grpc ref-client [flags]
+
+Flags:
+  -h, --help   help for ref-client
+
+Global Flags:
+  -l, --logLevel string   log level, must be one of: panic, fatal, error, warn, info, debug (default "info")
+```
+
+#### Ref-Server
+
+```
+$ strest-grpc ref-server --help
+run a gRPC reference server
+
+Usage:
+  strest-grpc ref-server [flags]
+
+Flags:
+  -h, --help   help for ref-server
 
 Global Flags:
   -l, --logLevel string   log level, must be one of: panic, fatal, error, warn, info, debug (default "info")

--- a/cmd/refclient.go
+++ b/cmd/refclient.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/buoyantio/strest-grpc/refclient"
+	"github.com/spf13/cobra"
+)
+
+var refClientCmd = &cobra.Command{
+	Use:   "ref-client",
+	Short: "run a gRPC reference client",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		refclient.Run()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(refClientCmd)
+}

--- a/cmd/refserver.go
+++ b/cmd/refserver.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/buoyantio/strest-grpc/refserver"
+	"github.com/spf13/cobra"
+)
+
+var refServerCmd = &cobra.Command{
+	Use:   "ref-server",
+	Short: "run a gRPC reference server",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		refserver.Run()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(refServerCmd)
+}

--- a/refclient/refclient.go
+++ b/refclient/refclient.go
@@ -1,0 +1,66 @@
+package refclient
+
+import (
+	"io"
+
+	pb "github.com/buoyantio/strest-grpc/protos"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+func Run() {
+	address := "localhost:11111"
+
+	log.Infof("connecting to %s", address)
+
+	connOpts := []grpc.DialOption{grpc.WithInsecure()}
+	conn, err := grpc.Dial(address, connOpts...)
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewResponderClient(conn)
+
+	stream, err := client.StreamingGet(context.Background())
+	if err != nil {
+		log.Fatalf("%v.StreamingGet(_) = _, %v", client, err)
+	}
+
+	count := -1
+
+	receiving := make(chan struct{})
+	go func(stream pb.Responder_StreamingGetClient, receiving chan<- struct{}, count int) {
+		received := 0
+		for {
+			_, err := stream.Recv()
+			if err == nil {
+				received++
+			} else if err == io.EOF {
+				if received != count {
+					log.Error("stream.Recv() returned unexpected io.EOF")
+				}
+				break
+			} else if err != nil {
+				log.Errorf("stream.Recv() returned unexpected error: %s", err)
+				break
+			}
+		}
+
+		close(receiving)
+	}(stream, receiving, count)
+
+	err = stream.Send(&pb.StreamingResponseSpec{
+		Count: int32(count),
+	})
+	if err != nil {
+		log.Errorf("stream.Send returned %s", err)
+	}
+
+	<-receiving
+
+	err = stream.CloseSend()
+	if err != nil {
+		log.Errorf("stream.CloseSend() returned %s", err)
+	}
+}

--- a/refserver/refserver.go
+++ b/refserver/refserver.go
@@ -1,0 +1,65 @@
+package refserver
+
+import (
+	"errors"
+	"io"
+	"net"
+
+	pb "github.com/buoyantio/strest-grpc/protos"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func Run() {
+	address := ":11111"
+
+	log.Infof("starting gRPC server on %s\n", address)
+
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		log.Fatalf("listening on tcp:%s: %v", address, err)
+	}
+
+	opts := []grpc.ServerOption{}
+	s := grpc.NewServer(opts...)
+
+	pb.RegisterResponderServer(s, &refserver{})
+	s.Serve(lis)
+}
+
+type refserver struct{}
+
+func (*refserver) Get(ctx context.Context, in *pb.ResponseSpec) (*pb.ResponseReply, error) {
+	return &pb.ResponseReply{}, grpc.Errorf(codes.OK, "Error")
+}
+
+func (*refserver) StreamingGet(stream pb.Responder_StreamingGetServer) error {
+	for {
+		spec, err := stream.Recv()
+
+		if err == io.EOF {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if spec.Count < 0 {
+			return errors.New("invalid ResponseSpec, Count cannot be negative")
+		}
+
+		if spec.Count == 0 {
+			return nil
+		}
+
+		for i := int32(0); i < spec.Count; i++ {
+			if err := stream.Send(&pb.ResponseReply{}); err != nil {
+				log.Errorf("stream.Send returned %s", err)
+				return err
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add two new commands, `ref-client` and `ref-server`, to perform a single
bi-directional gRPC request, to aide in evaluating HTTP/2 and gRPC proxy
behavior.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>