### PR TITLE
Replace scratch with alpine for base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.10.2 as build
-WORKDIR /go/src/strest-grpc
+FROM golang:1.11.1-stretch as build
 ADD . /go/src/github.com/buoyantio/strest-grpc
 RUN CGO_ENABLED=0 go build -installsuffix cgo -o /go/bin/strest-grpc /go/src/github.com/buoyantio/strest-grpc/main.go
 
-FROM scratch
+FROM alpine:3.8
+RUN apk --update upgrade && \
+    apk add ca-certificates curl nghttp2 && \
+    update-ca-certificates && \
+    rm -rf /var/cache/apk/*
 COPY --from=build /go/bin /go/bin
 ENTRYPOINT ["/go/bin/strest-grpc"]


### PR DESCRIPTION
Using alpine as a base Docker image enables running a shell inside the
image for testing/debugging, and also more easily allows shipping with
curl and nghttp2.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>