### PR TITLE
Add --iterations to specify a budget for the experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Flags:
       --errorRate float             the chance to return an error
   -h, --help                        help for client
       --interval duration           reporting interval (default 10s)
+      --iterations uint             number of iterations for the experiment. Exits gracefully after `iterations * interval` (default 0, meaning infinite)
       --latencyPercentiles string   response latency percentile distribution. (e.g. 50=10,100=100) (default "100=0")
       --latencyUnit string          latency units [ms|us|ns] (default "ms")
       --lengthPercentiles string    response body length percentile distribution. (e.g. 50=100,100=1000) (default "100=0")

--- a/client/client.go
+++ b/client/client.go
@@ -716,8 +716,11 @@ func loop(
 			}
 			logIntervalReport(t, &cfg.Interval, iteration, good, bad, bytes, min, max,
 				latencyHist, jitterHist)
-			bytes, count, good, bad, max, min = 0, 0, 0, 0, 0, math.MaxInt64
 			iteration++
+			if cfg.NumIterations > 0 && iteration >= cfg.NumIterations {
+				cleanup <- struct{}{}
+			}
+			bytes, count, good, bad, max, min = 0, 0, 0, 0, 0, math.MaxInt64
 			latencyHist.Reset()
 			jitterHist.Reset()
 			previousinterval = t
@@ -735,6 +738,7 @@ type Config struct {
 	TotalRequests      uint
 	TotalTargetRps     uint
 	Interval           time.Duration
+	NumIterations      uint
 	LatencyPercentiles string
 	LengthPercentiles  string
 	ErrorRate          float64

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -29,6 +29,7 @@ func init() {
 	flags.UintVar(&clientCfg.TotalRequests, "totalRequests", 0, "total number of requests to send. default: infinite")
 	flags.UintVar(&clientCfg.TotalTargetRps, "totalTargetRps", 0, "target requests per second")
 	flags.DurationVar(&clientCfg.Interval, "interval", 10*time.Second, "reporting interval")
+	flags.UintVar(&clientCfg.NumIterations, "iterations", 0, "Number of iterations (0 for infinite)")
 	flags.StringVar(&clientCfg.LatencyPercentiles, "latencyPercentiles", "100=0", "response latency percentile distribution (in ms). (e.g. 50=10,100=100)")
 	flags.StringVar(&clientCfg.LengthPercentiles, "lengthPercentiles", "100=0", "response body length percentile distribution. (e.g. 50=100,100=1000)")
 	flags.Float64Var(&clientCfg.ErrorRate, "errorRate", 0.0, "the chance to return an error")


### PR DESCRIPTION
Similar to https://github.com/BuoyantIO/slow_cooker/pull/68

Note that ~10% of the time, I see the following problem with this PR : 
```
./strest-grpc client --interval=10s --iterations=3
2018-10-22T11:07:59+02:00   0    0.0B  94256/0 10s L:   0 [  0   0 ]    7 J:   0   0
2018-10-22T11:08:09+02:00   1    0.0B  91003/0 10s L:   0 [  0   0 ]    6 J:   0   0
2018-10-22T11:08:19+02:00   2    0.0B  84834/0 10s L:   0 [  0   0 ]    0 J:   0   0
2018-10-22T11:08:29+02:00   3    0.0B      1/0 10s L:   0 [  0   0 ]    0 J:   0   0
{
  "good": 270094,
  "bad": 0,
  "bytes": 0,
  "latency": {
    "p50": 0,
    "p75": 0,
    "p90": 0,
    "p95": 0,
    "p99": 0,
    "p999": 7
  },
  "jitter": {
    "p50": 0,
    "p75": 0,
    "p90": 0,
    "p95": 0,
    "p99": 0,
    "p999": 0
  }
}
```

There is an extra line printed with very few (I have only seen "1") requests in an extra and undesired iteration. Any idea how we can reliably avoid this ?