### PR TITLE
Update Dockerfile to go 1.14.2, alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-stretch as build
+FROM golang:1.14.2-stretch as build
 
 WORKDIR /strest-grpc
 
@@ -10,7 +10,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -installsuffix cgo -o ./strest-grpc
 
-FROM alpine:3.9
+FROM alpine:3.12
 RUN apk --update upgrade && \
     apk add ca-certificates curl nghttp2 && \
     update-ca-certificates && \


### PR DESCRIPTION
Update Dockerfile to Go 1.14.2 to match go.mod and circleCI.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>